### PR TITLE
Step 6 & 7 - User Defined Delimeters

### DIFF
--- a/src/components/Calculator.jsx
+++ b/src/components/Calculator.jsx
@@ -50,8 +50,25 @@ export default class Calculator extends React.Component {
   handleSubmit = event => {
     event.preventDefault()
     const { inputValues } = this.state
-    // remove all characters that do not match 0-9, ".", ",", "+", or a newline character \n
-    let scrubbedString = inputValues.replace(/[^0-9+.,\-\n]+/g, '')
+
+    // STEP 6 & STEP 7
+    // find any characters inbetween "//" and a newline, define that as a delimeter
+    const delimeterRegex = RegExp(/(?<=\/\/).*(?=\n)/, 'g')
+    const userDefinedDelimeter = delimeterRegex.test(inputValues)
+
+    let scrubbedString = ''
+    // if the user defined a delimeter, replace all delimeters with "+"
+    if (userDefinedDelimeter) {
+      const newDelim = inputValues.match(/(?<=\/\/).*(?=\n)/g)
+      var allDelims = new RegExp(newDelim, 'g')
+      const delimsReplaced = inputValues.replace(allDelims, '+')
+      // remove all characters that do not match 0-9, ".", ",", "+", or a newline character \n
+      scrubbedString = delimsReplaced.replace(/[^0-9+.,\-\n]+/g, '')
+    } else {
+      // remove all characters that do not match 0-9, ".", ",", "+", or a newline character \n
+      scrubbedString = inputValues.replace(/[^0-9+.,\-\n]+/g, '')
+    }
+
     // scrub last and first characters to be numbers only (or decimal or negative number), protect against negative first number
     if (
       isNaN(scrubbedString.charAt(0)) &&


### PR DESCRIPTION
6. Support 1 custom delimiter of a single character using the format: //{delimiter}\n{numbers}
examples: //#\n2#5 will return 7; //,\n2,ff,100 will return 102
all previous formats should also be supported

7. Support 1 custom delimiter of any length using the format: //[{delimiter}]\n{numbers}
example: //[***]\n11***22***33 will return 66
all previous formats should also be supported